### PR TITLE
doc:  EUMETSAT Data Tailor init and usage how-to pages

### DIFF
--- a/playbooks/eumetsat-data-tailor-flavour/README.md
+++ b/playbooks/eumetsat-data-tailor-flavour/README.md
@@ -138,3 +138,7 @@ ansible-playbook \
 |------|---------|
 | ewc-ansible-role-conda | https://github.com/ewcloud/ewc-ansible-role-conda |
 | ewc-ansible-role-data-tailor | https://github.com/ewcloud/ewc-ansible-role-data-tailor |
+
+## Operation
+Checkout the following how-to guides to learn about management of the Item after initial setup:
+* [How to initialize the environment](./docs/how-to/how-to-initialize-environment.md)

--- a/playbooks/eumetsat-data-tailor-flavour/docs/how-to/how-to-consume-data.md
+++ b/playbooks/eumetsat-data-tailor-flavour/docs/how-to/how-to-consume-data.md
@@ -1,0 +1,100 @@
+# How to consume data
+
+The Data Tailor standalone has multiple ways of use including:
+
+* [GUI Web-App (graphical user-interface)](https://user.eumetsat.int/resources/user-guides/data-tailor-standalone-guide#ID-Using-the-GUI)
+* [CLI (command line interface)](https://user.eumetsat.int/resources/user-guides/data-tailor-standalone-guide#ID-Using-the-CLI)
+* [Python Library](https://user.eumetsat.int/resources/user-guides/data-tailor-standalone-guide#ID-The-DT-Standalone-APIs)
+* [EUMDAC](https://user.eumetsat.int/resources/user-guides/eumetsat-data-access-client-eumdac-guide#ID-Data-Tailor-Standalone-in-EUMDAC)
+
+For more information, please refer to the [Data Tailor Standalone Guide](https://user.eumetsat.int/resources/user-guides/data-tailor-standalone-guide). 
+
+## Example
+
+> 💡 The `HRSEVIRI` product (`MSG3-SEVI-MSG15-0100-NA-20240613095742.896000000Z-NA.zip`) is downloaded and untouced. The download is done directly from the Data Store, using `eumdac`. 
+
+> 💡 `eumdac` is included in your Data Tailor instance. An example command for downloading data with it is: `eumdac download -c EO:EUM:DAT:MSG:HRSEVIRI --limit 1`
+
+Above command is downloading latest available product from HRSEVIRI collection.
+
+Below is a small example of using the application with CLI. 
+
+1. Activate the conda environment:
+
+```bash
+conda activate epct-desktop
+```
+
+2. Create a `chain.yaml` file:
+```bash
+product: HRSEVIRI
+format: netcdf4
+projection: geographic
+roi: western_europe
+filter:
+  bands:
+    - channel_9
+    - channel_10
+    - channel_11
+```
+
+3. Run your customisation using the command below:
+```bash
+epct run-chain -f chain.yaml MSG3-SEVI-MSG15-0100-NA-20240613095742.896000000Z-NA.zip
+```
+
+The output would like like:
+```
+2024-06-13 10:05:25 - PROCESSING.chain_runner[291] - INFO - Start process "4c15df87"
+2024-06-13 10:05:25 - PROCESSING.chain_runner[241] - INFO - WORKER: localhost
+2024-06-13 10:05:25 - PROCESSING.chain_runner[242] - INFO - PID: 17361
+2024-06-13 10:05:25 - PROCESSING.chain_runner[243] - INFO - backend: epct_gis_msg
+2024-06-13 10:05:25 - PROCESSING.chain_runner[244] - INFO - user: None
+2024-06-13 10:05:28 - PROCESSING.preprocessing[677] - INFO - Processing details - product: HRSEVIRI chain-name: None chain-details: -product: HRSEVIRI -format: NetCDF4 (simplified) -projection: Geographic / Plate-Carree -roi: Western Europe -filter: Custom
+2024-06-13 10:05:28 - PROCESSING.preprocessing[683] - INFO - ROI name: Western Europe - NSWE: [67, 35, -23, 16] - process: 4c15df87
+2024-06-13 10:05:28 - PROCESSING.preprocessing[684] - INFO - Input products: MSG3-SEVI-MSG15-0100-NA-20240613095742.896000000Z-NA.nat
+2024-06-13 10:05:28 - PROCESSING.epct_gis[742] - INFO - Expected steps: 6
+2024-06-13 10:05:28 - PROCESSING.epct_gis[744] - INFO - Starting step "IMPORT" 1/6 ...
+2024-06-13 10:05:28 - PROCESSING.vrt[90] - INFO - Command line and its output ...
+ 
+gdal_translate -of VRT -a_srs "+proj=geos +h=35785831 +lon_0=0.0 +ellps=GRS80 +no_defs" -a_ullr -5565747.7 5565747.7 5565747.7 -5565747.7 -b 9 -b 10 -b 11  RAD:/usr/local/miniconda/envs/epct-desktop/var/cache/epct/EPCT_HRSEVIRI_FPC_4c15df87/decompressed_data/MSG3-SEVI-MSG15-0100-NA-20240613095742.896000000Z-NA.nat /usr/local/miniconda/envs/epct-desktop/var/cache/epct/EPCT_HRSEVIRI_FPC_4c15df87/MSG3-SEVI-MSG15-0100-NA-20240613095742.896000000Z-NA.vrt
+ 
+2024-06-13 10:05:28 - PROCESSING.epct_gis[397] - INFO - a preliminary ROI is applied to the intermediate VRT
+2024-06-13 10:05:28 - PROCESSING.vrt[90] - INFO - Command line and its output ...
+ 
+gdalwarp -cutline /usr/local/miniconda/envs/epct-desktop/var/cache/epct/EPCT_HRSEVIRI_FPC_4c15df87/roi.shp -crop_to_cutline -cblend 10 -r near --config OGR_ENABLE_PARTIAL_REPROJECTION YES /usr/local/miniconda/envs/epct-desktop/var/cache/epct/EPCT_HRSEVIRI_FPC_4c15df87/MSG3-SEVI-MSG15-0100-NA-20240613095742.896000000Z-NA.vrt /usr/local/miniconda/envs/epct-desktop/var/cache/epct/EPCT_HRSEVIRI_FPC_4c15df87/MSG3-SEVI-MSG15-0100-NA-20240613095742.896000000Z-NA_roi.vrt
+ 
+2024-06-13 10:05:28 - PROCESSING.epct_gis[747] - INFO - ... step "IMPORT" finished!
+2024-06-13 10:05:28 - PROCESSING.epct_gis[754] - INFO - Starting step "FILTER" 2/6 ...
+2024-06-13 10:05:28 - PROCESSING.epct_gis[758] - INFO - ... step "FILTER" finished!
+2024-06-13 10:05:28 - PROCESSING.epct_gis[754] - INFO - Starting step "PROJECTION" 3/6 ...
+2024-06-13 10:05:28 - PROCESSING.vrt[90] - INFO - Command line and its output ...
+ 
+gdalwarp -overwrite --config CPL_MAX_ERROR_REPORTS 1 -of GTiff -co BIGTIFF=IF_SAFER -co COMPRESS=DEFLATE -ot Float32 -t_srs "EPSG:4326" --config THRESHOLD 0.005 -r near -srcnodata -1000.0 "/usr/local/miniconda/envs/epct-desktop/var/cache/epct/EPCT_HRSEVIRI_FPC_4c15df87/MSG3-SEVI-MSG15-0100-NA-20240613095742.896000000Z-NA_roi.vrt" "/usr/local/miniconda/envs/epct-desktop/var/cache/epct/EPCT_HRSEVIRI_FPC_4c15df87/intermediate_warped.tif"
+ 
+2024-06-13 10:05:32 - PROCESSING.epct_gis[647] - INFO - ... step "PROJECTION" finished!
+2024-06-13 10:05:32 - PROCESSING.epct_gis[754] - INFO - Starting step "ROI" 4/6 ...
+2024-06-13 10:05:32 - PROCESSING.vrt[90] - INFO - Command line and its output ...
+ 
+gdalwarp -overwrite --config CPL_MAX_ERROR_REPORTS 1 -te -23.0 35.0 16.0 67.0 -te_srs "EPSG:4326" --config THRESHOLD 0.005 -r near "/usr/local/miniconda/envs/epct-desktop/var/cache/epct/EPCT_HRSEVIRI_FPC_4c15df87/intermediate_warped.tif" "/usr/local/miniconda/envs/epct-desktop/var/cache/epct/EPCT_HRSEVIRI_FPC_4c15df87/intermediate_warped_cut.tif"
+ 
+2024-06-13 10:05:32 - PROCESSING.epct_gis[647] - INFO - ... step "ROI" finished!
+2024-06-13 10:05:32 - PROCESSING.epct_gis[754] - INFO - Starting step "FORMAT" 5/6 ...
+2024-06-13 10:05:32 - PROCESSING.vrt[90] - INFO - Command line and its output ...
+ 
+gdal_translate -of netCDF -co FORMAT=NC4 -ot Float32 "/usr/local/miniconda/envs/epct-desktop/var/cache/epct/EPCT_HRSEVIRI_FPC_4c15df87/intermediate_warped_cut.tif" "/usr/local/miniconda/envs/epct-desktop/var/cache/epct/EPCT_HRSEVIRI_FPC_4c15df87/OUTPUTS/EPCT_HRSEVIRI_FPC_4c15df87.nc"
+ 
+2024-06-13 10:05:32 - PROCESSING.epct_gis[647] - INFO - ... step "FORMAT" finished!
+2024-06-13 10:05:32 - PROCESSING.postprocessing[468] - INFO - Starting step "POST-PROCESSING" 6/6 ...
+2024-06-13 10:05:32 - PROCESSING.postprocessing[493] - INFO - ... step "POST-PROCESSING" finished!
+2024-06-13 10:05:32 - PROCESSING.postprocessing[495] - INFO - output-product: ./HRSEVIRI_20240613T094510Z_20240613T095742Z_epct_4c15df87_FPC.nc
+2024-06-13 10:05:32 - PROCESSING.postprocessing[503] - INFO - customisation time: 7 - process: 4c15df87
+2024-06-13 10:05:32 - PROCESSING.postprocessing[504] - INFO - *** STOP PROCESSING - Status DONE ***
+ 
+processing-time: 6.8 [sec]
+```
+
+## Resources
+
+- [How to initialize the environmet](../how-to/how-to-initialize-environment.md )
+- [Data Tailor Standalone Guide](https://user.eumetsat.int/resources/user-guides/data-tailor-standalone-guide)

--- a/playbooks/eumetsat-data-tailor-flavour/docs/how-to/how-to-initialize-environment.md
+++ b/playbooks/eumetsat-data-tailor-flavour/docs/how-to/how-to-initialize-environment.md
@@ -98,13 +98,12 @@ executable_paths:
   epct_plugin_netcdf_generator: null
 ```
 
-The `Data Tailor Standalone` instance is now ready to use. 
-Whenever you want to use the application, just activate your conda environment with
+The `Data Tailor Standalone` instance is now ready for starting data comsuption. 
+Whenever you want to run your data consumption customization, make sure to first activate your environment with a command like:
 
 ```bash
 conda activate epct-desktop
 ```
-The you can start consuming data.
 
 ## Resources
 

--- a/playbooks/eumetsat-data-tailor-flavour/docs/how-to/how-to-initialize-environment.md
+++ b/playbooks/eumetsat-data-tailor-flavour/docs/how-to/how-to-initialize-environment.md
@@ -1,0 +1,112 @@
+# How to initialize the environmet
+
+1. SSH into your Data Tailor instance.
+2. Verify the installation by running:
+```bash
+conda env list
+```
+The output should look like:
+
+```
+# conda environments:
+#
+base                  *  /usr/local/miniconda
+epct-desktop             /usr/local/miniconda/envs/epct-desktop
+```
+3. Add conda environment to your shell and then restart it:
+
+```bash
+conda init
+```
+The output may look as follows:
+```
+no change     /usr/local/miniconda/condabin/conda
+no change     /usr/local/miniconda/bin/conda
+no change     /usr/local/miniconda/bin/conda-env
+no change     /usr/local/miniconda/bin/activate
+no change     /usr/local/miniconda/bin/deactivate
+no change     /usr/local/miniconda/etc/profile.d/conda.sh
+no change     /usr/local/miniconda/etc/fish/conf.d/conda.fish
+no change     /usr/local/miniconda/shell/condabin/Conda.psm1
+no change     /usr/local/miniconda/shell/condabin/conda-hook.ps1
+no change     /usr/local/miniconda/lib/python3.11/site-packages/xontrib/conda.xsh
+no change     /usr/local/miniconda/etc/profile.d/conda.csh
+modified      /home/USERNAME/.bashrc
+ 
+==> For changes to take effect, close and re-open your current shell. <==
+```
+
+4. Restart your shell (close and re-open it)
+5. Activate the conda environment and test the application
+```bash
+conda activate epct-desktop
+```
+
+The output should resemble something like:
+```
+epct_version: 3.4.0
+etc_dir: /usr/local/miniconda/envs/epct-desktop/etc/epct
+workspace_dir: /usr/local/miniconda/envs/epct-desktop/var/cache/epct
+customisations_log_dir: /usr/local/miniconda/envs/epct-desktop/var/log/epct
+output_dir: /
+installed_plugins:
+  - epct-plugin-netcdf-generator, 3.1.1
+  - epct-plugin-ncarrays, 1.1.0
+  - epct-plugin-umarf, 3.2.0
+  - epct-plugin-gis, 3.3.0
+registered_backends:
+  - epct_1d_array
+  - epct_2d_array
+  - epct_ascatl1szf
+  - epct_eps_gome2l1b
+  - epct_eps_grasl1
+  - epct_eps_iasil1c
+  - epct_eps_iasisnd02
+  - epct_eps_native
+  - epct_eps_native_gome2l1_iasisnd02
+  - epct_gis
+  - epct_gis_eps
+  - epct_gis_eps_grib2
+  - epct_gis_fcil2
+  - epct_gis_glbsst
+  - epct_gis_glbsst_grib2
+  - epct_gis_grib2
+  - epct_gis_hrit
+  - epct_gis_hrit_grib2
+  - epct_gis_hrit_png_16_bit
+  - epct_gis_msg
+  - epct_gis_msg_meteo_bufr
+  - epct_gis_msg_png_16_bit
+  - epct_gis_mtgfcil1
+  - epct_or1sww025
+  - epct_plugin_netcdf_generator
+  - epct_plugin_umarf_isccp
+  - epct_plugin_umarf_isccp_nat
+  - epct_plugin_umarf_msgclmk_grib
+  - epct_plugin_umarf_msgclmk_netcdf
+  - epct_plugin_umarf_msgnative
+  - epct_plugin_umarf_msgnative_hrv_nat
+  - epct_plugin_umarf_msgnative_nat
+  - epct_plugin_umarf_openmtp
+  - epct_plugin_umarf_rgb_dc_jpeg
+  - epct_plugin_umarf_rgb_dc_jpeg_nat
+  - epct_plugin_umarf_rgb_dc_png
+  - epct_plugin_umarf_rgb_dc_png_nat
+  - epct_plugin_umarf_xrit
+  - epct_plugin_umarf_xrit_nat
+executable_paths:
+  epct_plugin_netcdf_generator: null
+```
+
+The `Data Tailor Standalone` instance is now ready to use. 
+Whenever you want to use the application, just activate your conda environment with
+
+```bash
+conda activate epct-desktop
+```
+The you can start consuming data.
+
+## Resources
+
+- [How to consume data](../how-to/how-to-consume-data.md)
+- [Data Tailor Standalone Guide](https://user.eumetsat.int/resources/user-guides/data-tailor-standalone-guide)

--- a/playbooks/ipa-server-flavour/docs/how-to/how-to-administrate-ipa-user-public-ssh-keys.md
+++ b/playbooks/ipa-server-flavour/docs/how-to/how-to-administrate-ipa-user-public-ssh-keys.md
@@ -32,3 +32,7 @@ ipa user-mod bob --sshpubkey="key1==,key2==,key3=="
 
 ![](../images/ipa-ui-add-public-ssh-keys.png)
 
+## Resources
+
+- [How to configure the IPA server](../how-to/how-to-configure-the-ipa-server.md)
+- [FreeIPA Official Documentation](https://www.freeipa.org/page/Documentation)

--- a/playbooks/ipa-server-flavour/docs/how-to/how-to-configure-the-ipa-server.md
+++ b/playbooks/ipa-server-flavour/docs/how-to/how-to-configure-the-ipa-server.md
@@ -284,4 +284,5 @@ ipa dnsrecord-del <Zone Name> <Record Name> --del-all
 
 ## Resources
 
+- [How to administrate IPA users' public SSH keys](../how-to/how-to-administrate-ipa-user-public-ssh-keys.md)
 - [FreeIPA Official Documentation](https://www.freeipa.org/page/Documentation)


### PR DESCRIPTION
Hi @pacospace,

This is a follow up PR to migrate relevant Item docs out of Confluence and next to the Community Hub Items themselves.

This one is specific to the "EUMETSAT - Data Tailor Standalone Instance" page [1].

Additionally, created some links about How-to pages, which were missing #23. 


[1] https://confluence.ecmwf.int/x/1Q_LFw