### PR TITLE
fix: Move from IPA Client host whilelsiting to blacklisting



### DIFF
--- a/playbooks/ipa-client-enroll-flavour/ipa-client-enroll-flavour.yml
+++ b/playbooks/ipa-client-enroll-flavour/ipa-client-enroll-flavour.yml
@@ -34,7 +34,7 @@
         ipa_admin_password_fact: "{{ ipa_admin_password }}"
 
 - name: Install IPA client and enroll into an IPA server's LDAP/DNS services
-  hosts: ipa_client
+  hosts: all:!ipa_server
   become: true
   become_user: root
   become_method: ansible.builtin.sudo


### PR DESCRIPTION
This is to preserve functionality of Item that depend on this one
(i.e. Default Stack Provisioning) while also complying with new
requirements of the EWCCLI, which expects Items to target `all` hosts as
its lacks functionality to create an in-memory inventory as per specific
needs of each Item.