### PR TITLE
docs: Better guidelines on installing latest requirements.

### DIFF
--- a/playbooks/default-stack-provisioning/README.md
+++ b/playbooks/default-stack-provisioning/README.md
@@ -76,7 +76,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Configure and apply the template

--- a/playbooks/eumetcast-terrestrial-amt-flavour/README.md
+++ b/playbooks/eumetcast-terrestrial-amt-flavour/README.md
@@ -85,7 +85,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Specify the target host and SSH credentials

--- a/playbooks/eumetcast-terrestrial-amt-flavour/README.md
+++ b/playbooks/eumetcast-terrestrial-amt-flavour/README.md
@@ -6,7 +6,7 @@ within the [European Weather Cloud (EWC)](https://europeanweather.cloud/), to eq
 
 EUMETCast is EUMETSAT’s primary dissemination mechanism for the near-real-time delivery of satellite data. EUMETCast serves data through two complementary delivery systems: EUMETCast Satellite and EUMETCast Terrestrial.
 
-![EUMETCast overview](./docs/images/eumetcast-overview.png)
+![EUMETCast overview](https://raw.githubusercontent.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/refs/heads/main/playbooks/eumetcast-terrestrial-amt-flavour/docs/images/eumetcast-overview.png)
 
 Terrestrial services for data distribution, available and supported, include:
 

--- a/playbooks/eumetsat-data-tailor-flavour/README.md
+++ b/playbooks/eumetsat-data-tailor-flavour/README.md
@@ -61,7 +61,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Specify the target host and SSH credentials

--- a/playbooks/eumetsat-s3-mount-flavour/README.md
+++ b/playbooks/eumetsat-s3-mount-flavour/README.md
@@ -59,7 +59,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Specify the target host and SSH credentials

--- a/playbooks/haproxy-flavour/README.md
+++ b/playbooks/haproxy-flavour/README.md
@@ -66,7 +66,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Specify the target host and SSH credentials

--- a/playbooks/ipa-client-disenroll-flavour/README.md
+++ b/playbooks/ipa-client-disenroll-flavour/README.md
@@ -60,7 +60,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Specify the target host and SSH credentials

--- a/playbooks/ipa-client-enroll-flavour/README.md
+++ b/playbooks/ipa-client-enroll-flavour/README.md
@@ -66,7 +66,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Specify the target host and SSH credentials

--- a/playbooks/ipa-client-provisioning/README.md
+++ b/playbooks/ipa-client-provisioning/README.md
@@ -69,7 +69,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Configure and apply the template

--- a/playbooks/ipa-client-teardown/README.md
+++ b/playbooks/ipa-client-teardown/README.md
@@ -63,7 +63,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Configure and apply the template

--- a/playbooks/ipa-server-flavour/README.md
+++ b/playbooks/ipa-server-flavour/README.md
@@ -69,7 +69,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Specify the target host and SSH credentials

--- a/playbooks/ipa-server-provisioning/README.md
+++ b/playbooks/ipa-server-provisioning/README.md
@@ -79,7 +79,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Configure and apply the template

--- a/playbooks/nginx-proxy-manager-flavour/README.md
+++ b/playbooks/nginx-proxy-manager-flavour/README.md
@@ -67,7 +67,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Specify the target host and SSH credentials

--- a/playbooks/remote-desktop-flavour/README.md
+++ b/playbooks/remote-desktop-flavour/README.md
@@ -71,7 +71,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Specify the target host and SSH credentials

--- a/playbooks/remote-desktop-provisioning/README.md
+++ b/playbooks/remote-desktop-provisioning/README.md
@@ -78,7 +78,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Configure and apply the template

--- a/playbooks/ssh-bastion-flavour/README.md
+++ b/playbooks/ssh-bastion-flavour/README.md
@@ -66,7 +66,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Specify the target host and SSH credentials

--- a/playbooks/ssh-bastion-provisioning/README.md
+++ b/playbooks/ssh-bastion-provisioning/README.md
@@ -76,7 +76,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Configure and apply the template

--- a/playbooks/xcube-viewer-flavour/README.md
+++ b/playbooks/xcube-viewer-flavour/README.md
@@ -63,7 +63,7 @@ git checkout x.y.z
 Download the correct version of the Ansible dependencies, if you haven't done so already:
 
 ```
-ansible-galaxy role install -r requirements.yml
+ansible-galaxy role install --force -r requirements.yml
 ```
 
 ### 3. Specify the target host and SSH credentials


### PR DESCRIPTION
Using the snippets we provided before might lead to cases in which Ansible complains an older version was already installed. The warning advice to re-run with the `--force` argument to ensure the latest patch of each role is pulled. Adding that to avoid the warning altogether.