### PR TITLE
feat: IPA server provisioning updates also subnet DNS nameservers

### DIFF
--- a/playbooks/default-stack-provisioning/README.md
+++ b/playbooks/default-stack-provisioning/README.md
@@ -40,7 +40,7 @@ to their DNS configuration.
 * Create an SSH keypair and import the public SSH key to OpenStack (see [EWC OpenStack API access - Setup a KeyPair](https://confluence.ecmwf.int/x/0ZglK) section of the EWC documentation).
 
 ## Usage
-> ⚠️ Only RockyLinux versions 9 or 8 are supported due
+> ⚠️ Only RockyLinux is supported due
 to constrains imposed by [dependencies](#dependencies).
 
 > 💡 VM plans with at least 4GB of RAM is recommended for successful setup and stable operation 

--- a/playbooks/default-stack-provisioning/default-stack-provisioning.yml
+++ b/playbooks/default-stack-provisioning/default-stack-provisioning.yml
@@ -178,44 +178,6 @@
 - name: Provision IPA Server
   import_playbook: "../ipa-server-provisioning/ipa-server-provisioning.yml"
 
-- name: Update OpenStack subnet DNS nameservers for IPA compatibility
-  hosts: localhost
-  connection: local
-  gather_facts: false
-
-  tasks:
-    - name: Gather information about user-specified OpenStack network
-      openstack.cloud.networks_info:
-        name: "{{ private_network_name }}"
-      register: networks_info
-
-    - name: Get ID of user-defined network
-      ansible.builtin.set_fact:
-        network_id: "{{ networks_info.networks[0].id }}"
-
-    - name: Gather information about subnets within user-defined OpenStack network
-      openstack.cloud.subnets_info:
-        filters:
-          network_id: "{{ network_id }}"
-      register: subnets_info
-
-    - name: Get name, ID, CIDR and DNS nameservers of subnet (choose first)
-      ansible.builtin.set_fact:
-        subnet_name: "{{ subnets_info.subnets[0].name }}"
-        subnet_cidr: "{{ subnets_info.subnets[0].cidr }}"
-        subnet_dns_nameservers: "{{ subnets_info.subnets[0].dns_nameservers | default([]) }}"
-
-    - name: Point DNS nameservers in OpenStack subnet to new IPA server
-      openstack.cloud.subnet:
-        network: "{{ private_network_name }}"
-        name: "{{ subnet_name }}"
-        cidr: "{{ subnet_cidr }}"
-        dns_nameservers:
-          - "{{ hostvars['localhost']['remote_host_internal_ip_fact'] }}"
-        state: present
-      register: subnet_result
-      no_log: true
-
 - name: Provision SSH Bastion
   import_playbook: "../ssh-bastion-provisioning/ssh-bastion-provisioning.yml"
 

--- a/playbooks/ipa-client-provisioning/README.md
+++ b/playbooks/ipa-client-provisioning/README.md
@@ -41,8 +41,6 @@ To learn the basics about managing infrastructure with Terraform, check out [Ter
 * Create an SSH keypair and import the public SSH key to OpenStack (see [EWC OpenStack API access - Setup a KeyPair](https://confluence.ecmwf.int/x/0ZglK) section of the EWC documentation).
 
 ## Usage
-> ⚠️ Only Ubuntu version 24 or 22, and RockyLinux versions 9 or 8 supported due to constrains imposed by [dependencies](#dependencies).
-
 
 ### 1. Clone the repository
 

--- a/playbooks/ipa-client-provisioning/ipa-client-provisioning.yml
+++ b/playbooks/ipa-client-provisioning/ipa-client-provisioning.yml
@@ -172,7 +172,9 @@
             # by Ansible via ssh from localhost. It'll be removed after successful start if not requested by the user!
             instance_has_fip = true
 
+            {% if  hostvars['localhost']['ewc_tf_module_openstack_compute']['os_volume'] is not none %}
             os_volume = {{ hostvars['localhost']['ewc_tf_module_openstack_compute']['os_volume'] | to_json }}
+            {% endif %}
 
             tags = {
               provisioning-tool = "terraform"
@@ -244,7 +246,7 @@
         ansible_host: "{{ remote_host_public_ip_fact }}"
         ansible_user: "{{ 'ubuntu' if image_name | lower | regex_search('^ubuntu') else 'cloud-user' }}"
         ansible_ssh_private_key_file: "{{ hostvars['localhost']['private_keypair_path_fact'] }}"
-        ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
 
 - name: Install IPA client and enroll into an IPA server's LDAP/DNS services
   hosts: ipa_client

--- a/playbooks/ipa-server-provisioning/README.md
+++ b/playbooks/ipa-server-provisioning/README.md
@@ -53,6 +53,10 @@ To learn the basics about managing infrastructure with Terraform, check out [Ter
 > 💡 A VM plan with at least 4GB of RAM is recommended for successful setup and
 stable operation.
 
+>⛔ Execution of this template can potentially affect DNS resolution on existing VMs within your subnet. To prevent issues, enroll them to the new IPA server via the
+[IPA Client Enroll Flavour](https://europeanweather.cloud/community-hub/ipa-client-enroll-flavour)
+CommunityHub Item, OR manually [edit nameservers in their DNS configuration](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/identity_management_guide/domain-dns).
+
 
 ### 1. Clone the repository
 

--- a/playbooks/ipa-server-provisioning/README.md
+++ b/playbooks/ipa-server-provisioning/README.md
@@ -48,7 +48,7 @@ To learn the basics about managing infrastructure with Terraform, check out [Ter
 * Create an SSH keypair and import the public SSH key to OpenStack (see [EWC OpenStack API access - Setup a KeyPair](https://confluence.ecmwf.int/x/0ZglK) section of the EWC documentation).
 
 ## Usage
-> ⚠️ Only RockyLinux version 8 supported due to constrains imposed by [dependencies](#dependencies).
+> ⚠️ Only RockyLinux is supported due to constrains imposed by [dependencies](#dependencies).
 
 > 💡 A VM plan with at least 4GB of RAM is recommended for successful setup and
 stable operation.

--- a/playbooks/ipa-server-provisioning/README.md
+++ b/playbooks/ipa-server-provisioning/README.md
@@ -124,29 +124,6 @@ ansible-playbook \
     }' \
   ipa-server-provisioning.yml
 ```
-### 4. Manually update DNS nameserver(s)
-
->⛔ Changes described in this section can potentially affect DNS resolution on existing VMs within your subnet. To prevent issues, enroll them to the new IPA server via the
-[IPA Client Enroll Flavour](https://europeanweather.cloud/community-hub/ipa-client-enroll-flavour)
-CommunityHub Item, OR manually [edit nameservers in their DNS configuration](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/identity_management_guide/domain-dns).
-
-After successful execution of the template, additional changes to the OpenStack subnet are required.
-You can edit your specific OpenStack subnet, as well as any other OpenStack resource, with the native [OpenStack CLI](pypi.org/project/python-openstackclient/).
-
-First, take note of the IP address of your newly configured IPA server and the subnet attached to it, replace these information in the command below, and execute:
-
-```bash
-openstack subnet set \
-  --dns-nameserver <IPV4 address of the IPA server> \
-  <ID or name of the OpenStack Subnet attached to the IPA server>
-```
-Then remove any default DNS nameservers which where added to the subnet prior to the IPA server configuration:
-
-```bash
-openstack subnet unset \
-  --dns-nameserver <IPV4 address of any prior default DNS nameserver> \
-  <ID or name of the OpenStack Subnet attached to the IPA server>
-```
 
 ## Inputs
 

--- a/playbooks/ipa-server-provisioning/ipa-server-provisioning.yml
+++ b/playbooks/ipa-server-provisioning/ipa-server-provisioning.yml
@@ -248,7 +248,7 @@
         ansible_host: "{{ remote_host_public_ip_fact }}"
         ansible_user: "cloud-user"
         ansible_ssh_private_key_file: "{{ hostvars['localhost']['private_keypair_path_fact'] }}"
-        ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
 
 - name: Install IPA server
   hosts: ipa_server
@@ -270,13 +270,51 @@
         os_network_name: "{{ hostvars['localhost']['ewc_ansible_role_ipa_server']['os_network_name_fact'] }}"
         os_security_group_name: "{{ hostvars['localhost']['ewc_ansible_role_ipa_server']['os_security_group_name_fact'] }}"
 
+- name: Update OpenStack subnet DNS nameservers for IPA compatibility
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Gather information about user-specified OpenStack network
+      openstack.cloud.networks_info:
+        name: "{{ private_network_name }}"
+      register: networks_info
+
+    - name: Get ID of user-defined network
+      ansible.builtin.set_fact:
+        network_id: "{{ networks_info.networks[0].id }}"
+
+    - name: Gather information about subnets within user-defined OpenStack network
+      openstack.cloud.subnets_info:
+        filters:
+          network_id: "{{ network_id }}"
+      register: subnets_info
+
+    - name: Get name, ID, CIDR and DNS nameservers of subnet (choose first)
+      ansible.builtin.set_fact:
+        subnet_name: "{{ subnets_info.subnets[0].name }}"
+        subnet_cidr: "{{ subnets_info.subnets[0].cidr }}"
+        subnet_dns_nameservers: "{{ subnets_info.subnets[0].dns_nameservers | default([]) }}"
+
+    - name: Point DNS nameservers in OpenStack subnet to new IPA server
+      openstack.cloud.subnet:
+        network: "{{ private_network_name }}"
+        name: "{{ subnet_name }}"
+        cidr: "{{ subnet_cidr }}"
+        dns_nameservers:
+          - "{{ hostvars['localhost']['remote_host_internal_ip_fact'] }}"
+        state: present
+      register: subnet_result
+      no_log: true
+
 - name: Cleanup and summarize execution after post-provisioning
   hosts: localhost
   connection: local
   gather_facts: false
 
   tasks:
-    - name: Update intance's Terraform definition file
+    - name: Update instance's Terraform definition file
       ansible.builtin.lineinfile:
         path: "{{ hostvars['localhost']['tf_project_path_fact'] }}/main.tf"
         search_string: 'instance_has_fip'

--- a/playbooks/ipa-server-provisioning/ipa-server-provisioning.yml
+++ b/playbooks/ipa-server-provisioning/ipa-server-provisioning.yml
@@ -176,7 +176,9 @@
             # by Ansible via ssh from localhost. It'll be removed after successful start!
             instance_has_fip = true
 
+            {% if  hostvars['localhost']['ewc_tf_module_openstack_compute']['os_volume'] is not none %}
             os_volume = {{ hostvars['localhost']['ewc_tf_module_openstack_compute']['os_volume'] | to_json }}
+            {% endif %}
 
             tags = {
               provisioning-tool = "terraform"

--- a/playbooks/ipa-server-provisioning/requirements.yml
+++ b/playbooks/ipa-server-provisioning/requirements.yml
@@ -2,4 +2,4 @@
 roles:
   - name: ewc-ansible-role-ipa-server-1.1
     src: https://github.com/ewcloud/ewc-ansible-role-ipa-server.git
-    version: 1.1.1
+    version: 1.1.2

--- a/playbooks/remote-desktop-provisioning/README.md
+++ b/playbooks/remote-desktop-provisioning/README.md
@@ -48,7 +48,7 @@ To learn the basics about managing infrastructure with Terraform, check out [Ter
 * Create an SSH keypair and import the public SSH key to OpenStack (see [EWC OpenStack API access - Setup a KeyPair](https://confluence.ecmwf.int/x/0ZglK) section of the EWC documentation).
 
 ## Usage
-> ⚠️ Only RockyLinux version 9 and 8 supported due to constrains imposed by [dependencies](#dependencies).
+> ⚠️ Only RockyLinux is supported due to constrains imposed by [dependencies](#dependencies).
 
 > 💡 A VM plan with at least 4GB of RAM is recommended for successful setup and
 stable operation.

--- a/playbooks/remote-desktop-provisioning/remote-desktop-provisioning.yml
+++ b/playbooks/remote-desktop-provisioning/remote-desktop-provisioning.yml
@@ -155,7 +155,9 @@
             # by Ansible via ssh from localhost. It'll be removed after successful start!
             instance_has_fip = true
 
+            {% if  hostvars['localhost']['ewc_tf_module_openstack_compute']['os_volume'] is not none %}
             os_volume = {{ hostvars['localhost']['ewc_tf_module_openstack_compute']['os_volume'] | to_json }}
+            {% endif %}
 
             tags = {
               provisioning-tool = "terraform"
@@ -228,7 +230,7 @@
         ansible_host: "{{ remote_host_public_ip_fact }}"
         ansible_user: "cloud-user"
         ansible_ssh_private_key_file: "{{ hostvars['localhost']['private_keypair_path_fact'] }}"
-        ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
 
 - name: Configure Remote Desktop server
   hosts: remote_desktop

--- a/playbooks/ssh-bastion-provisioning/README.md
+++ b/playbooks/ssh-bastion-provisioning/README.md
@@ -46,7 +46,7 @@ To learn the basics about managing infrastructure with Terraform, check out [Ter
 * Create an SSH keypair and import the public SSH key to OpenStack (see [EWC OpenStack API access - Setup a KeyPair](https://confluence.ecmwf.int/x/0ZglK) section of the EWC documentation).
 
 ## Usage
-> ⚠️ Only RockyLinux version 9 and 8 supported due to constrains imposed by [dependencies](#dependencies).
+> ⚠️ Only RockyLinux is supported due to constrains imposed by [dependencies](#dependencies).
 
 > 💡 A VM plan with at least 4GB of RAM is recommended for successful setup and
 stable operation.

--- a/playbooks/ssh-bastion-provisioning/ssh-bastion-provisioning.yml
+++ b/playbooks/ssh-bastion-provisioning/ssh-bastion-provisioning.yml
@@ -149,7 +149,9 @@
             # by Ansible via ssh from localhost. It'll be removed after successful start!
             instance_has_fip = true
 
+            {% if  hostvars['localhost']['ewc_tf_module_openstack_compute']['os_volume'] is not none %}
             os_volume = {{ hostvars['localhost']['ewc_tf_module_openstack_compute']['os_volume'] | to_json }}
+            {% endif %}
 
             tags = {
               provisioning-tool = "terraform"
@@ -222,7 +224,7 @@
         ansible_host: "{{ remote_host_public_ip_fact }}"
         ansible_user: "cloud-user"
         ansible_ssh_private_key_file: "{{ hostvars['localhost']['private_keypair_path_fact'] }}"
-        ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
 
 - name: Configure SSH bastion server
   hosts: "ssh_bastion"


### PR DESCRIPTION
This PR moves functionality to autoconfigure OpenStack subnet DNS nameservers, from the `default-stack-provisioning` Item one level below, down to the relevant component, the `ipa-server-provisioning` Item.

The idea is simple: Ensure OpenStack subnet DNS nameservers are updated automatically when an IPA server is provisioned via either the `default-stack-provisioning` Item or the `ipa-server-provisioning` Item. 

**IMPORTANT:** Manual modifications are still needed if one configures an existing VM via EWCCLI or the `ipa-server-flavour` Item, as documented [on the Item itself](https://github.com/ewcloud/ewc-ansible-playbook-flavours-and-provisioning/tree/1.9.0/playbooks/ipa-server-flavour#5-manually-update-dns-nameservers).