### PR TITLE
fix: IPA server stability and Remote Desktop dependencies

### DIFF
--- a/playbooks/default-stack-provisioning/requirements.yml
+++ b/playbooks/default-stack-provisioning/requirements.yml
@@ -2,7 +2,7 @@
 roles:
   - name: ewc-ansible-role-ipa-server-1.1
     src: https://github.com/ewcloud/ewc-ansible-role-ipa-server.git
-    version: 1.1.1
+    version: 1.1.3
 
   - name: ewc-ansible-role-ipa-client-enroll-1.2
     src: https://github.com/ewcloud/ewc-ansible-role-ipa-client-enroll.git
@@ -12,6 +12,6 @@ roles:
     src: https://github.com/ewcloud/ewc-ansible-role-ssh-bastion.git
     version: 1.5.2
 
-  - name: ewc-ansible-role-remote-desktop-1.3
+  - name: ewc-ansible-role-remote-desktop-1.4
     src: https://github.com/ewcloud/ewc-ansible-role-remote-desktop.git
-    version: 1.3.2
+    version: 1.4.0

--- a/playbooks/ipa-server-flavour/requirements.yml
+++ b/playbooks/ipa-server-flavour/requirements.yml
@@ -2,4 +2,4 @@
 roles:
   - name: ewc-ansible-role-ipa-server-1.1
     src: https://github.com/ewcloud/ewc-ansible-role-ipa-server.git
-    version: 1.1.2
+    version: 1.1.3

--- a/playbooks/ipa-server-provisioning/ipa-server-provisioning.yml
+++ b/playbooks/ipa-server-provisioning/ipa-server-provisioning.yml
@@ -250,7 +250,7 @@
         ansible_host: "{{ remote_host_public_ip_fact }}"
         ansible_user: "cloud-user"
         ansible_ssh_private_key_file: "{{ hostvars['localhost']['private_keypair_path_fact'] }}"
-        ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes"
 
 - name: Install IPA server
   hosts: ipa_server

--- a/playbooks/ipa-server-provisioning/requirements.yml
+++ b/playbooks/ipa-server-provisioning/requirements.yml
@@ -2,4 +2,4 @@
 roles:
   - name: ewc-ansible-role-ipa-server-1.1
     src: https://github.com/ewcloud/ewc-ansible-role-ipa-server.git
-    version: 1.1.2
+    version: 1.1.3

--- a/playbooks/remote-desktop-flavour/remote-desktop-flavour.yml
+++ b/playbooks/remote-desktop-flavour/remote-desktop-flavour.yml
@@ -23,6 +23,6 @@
   tasks:
     - name: EWC Ansible Role Remote Desktop
       ansible.builtin.include_role:
-        name: ewc-ansible-role-remote-desktop-1.3
+        name: ewc-ansible-role-remote-desktop-1.4
       vars:
         fail2ban_whitelisted_ip_ranges: "{{ hostvars['localhost']['fail2ban_whitelisted_ip_ranges_fact'] }}"

--- a/playbooks/remote-desktop-flavour/requirements.yml
+++ b/playbooks/remote-desktop-flavour/requirements.yml
@@ -1,5 +1,5 @@
 ---
 roles:
-  - name: ewc-ansible-role-remote-desktop-1.3
+  - name: ewc-ansible-role-remote-desktop-1.4
     src: https://github.com/ewcloud/ewc-ansible-role-remote-desktop.git
-    version: 1.3.2
+    version: 1.4.0

--- a/playbooks/remote-desktop-provisioning/remote-desktop-provisioning.yml
+++ b/playbooks/remote-desktop-provisioning/remote-desktop-provisioning.yml
@@ -240,7 +240,7 @@
   tasks:
     - name: EWC Ansible Role Remote Desktop
       ansible.builtin.include_role:
-        name: ewc-ansible-role-remote-desktop-1.3
+        name: ewc-ansible-role-remote-desktop-1.4
       vars:
         fail2ban_whitelisted_ip_ranges: "{{ hostvars['localhost']['ewc_ansible_role_remote_desktop']['fail2ban_whitelisted_ip_ranges_fact'] }}"
 

--- a/playbooks/remote-desktop-provisioning/requirements.yml
+++ b/playbooks/remote-desktop-provisioning/requirements.yml
@@ -1,5 +1,5 @@
 ---
 roles:
-  - name: ewc-ansible-role-remote-desktop-1.3
+  - name: ewc-ansible-role-remote-desktop-1.4
     src: https://github.com/ewcloud/ewc-ansible-role-remote-desktop.git
-    version: 1.3.2
+    version: 1.4.0


### PR DESCRIPTION
The `default-stack-provisioning` and two of its components are patched to ensure successful deployment. Tested manually on RockyLinux 9.7. 
Updated Items work on ECMWF site as well.